### PR TITLE
from settings to a datafile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *pyc
+.vscode

--- a/octoprint_powerfailure/__init__.py
+++ b/octoprint_powerfailure/__init__.py
@@ -253,7 +253,7 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
                 self.timer.cancel()
                 self.clean()
             elif event in {"PrintFailed"}:
-                self._logger.info("PowerFailure: Print failed with {0}".format(event["reason"]))
+                self._logger.info("PowerFailure: Print failed with {0}".format(payload["reason"]))
                 self.timer.cancel()
             else:
                 # casos pause y resume

--- a/octoprint_powerfailure/__init__.py
+++ b/octoprint_powerfailure/__init__.py
@@ -153,7 +153,7 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
                 gcode += "G92 " + ecommand + "\n"
             if fan and extruder:
                 break
-        #not fully understanding this yet, would be good to add linear advance code now if it is set
+        #not fully understanding this yet, would be good to add linear advance gcode now if it is set
         original = open(original_fn, 'r')
         original.seek(filepos)
         data = gcode + original.read()
@@ -253,8 +253,11 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
                 self.timer.cancel()
                 self.clean()
             elif event in {"PrintFailed"}:
-                self._logger.info("PowerFailure: Print failed with {0}".format(payload["reason"]))
                 self.timer.cancel()
+                self._logger.info("PowerFailure: Print failed with {0}".format(payload))
+                self.recovery_settings["powerloss"] = False
+                self._write_recovery_settings()
+                
             else:
                 # casos pause y resume
                 pass

--- a/octoprint_powerfailure/__init__.py
+++ b/octoprint_powerfailure/__init__.py
@@ -143,7 +143,7 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
         self._logger.info("Backup printing: %s Offset:%s Z:%s Bed:%s Tool:%s" % (
             filename, filepos, currentZ, bedT, tool0T))
         self._settings.setBoolean(["recovery"], True)
-        self._settings.setBoolean(["powerloss", True])
+        #self._settings.setBoolean(["powerloss", True])
         self._settings.set(["filename"], str(filename))
         self._settings.setInt(["filepos"], sanitize_number(filepos))
         self._settings.setFloat(["currentZ"], sanitize_number(currentZ))
@@ -183,12 +183,13 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
                 # empiezo a chequear
                 self.timer = RepeatedTimer(1.0, PowerFailurePlugin.backupState,
                                            args=[self],
-                                           on_condition_false=PowerFailurePlugin._timer_condition,
-                                           on_cancelled=PowerFailurePlugin._timer_cancel,
-                                           on_finish=PowerFailurePlugin._timer.finish,
+                                           on_condition_false=PowerFailurePlugin._timer_condition(self),
+                                           on_cancelled=PowerFailurePlugin._timer_cancel(self),
+                                           on_finish=PowerFailurePlugin._timer_finish(self),
                                            run_first=True,
                                            daemon=True)
                 self.timer.start()
+                self._logger.info("Timer started")
             # casos en que dejo de revisar y borro
             elif event in {"PrintDone", "PrintCancelled"}:
                 # cancelo el chequeo
@@ -196,7 +197,6 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
                 self.clean()
             elif event in {"PrintFailed"}:
                 self.timer.cancel()
-                self._settings.save()
             else:
                 # casos pause y resume
                 pass

--- a/octoprint_powerfailure/__init__.py
+++ b/octoprint_powerfailure/__init__.py
@@ -123,12 +123,14 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
 
     def backupState(self):
         currentData = self._printer.get_current_data()
+        '''
         if currentData["job"]["file"]["origin"] != "local":
             self._logger.info(
                 "SD printing does not support power failure recovery")
             self._settings.setBoolean(["recovery"], False)
             self.timer.cancel()
             return
+        '''
         currentTemp = self._printer.get_current_temperatures()
         bedT = currentTemp["bed"]["target"]
         tool0T = currentTemp["tool0"]["target"]
@@ -178,6 +180,9 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
             else:
                 # casos pause y resume
                 pass
+
+        if event.startswith("Error"):
+            self.timer.cancel()
 
     def check_queue(self, comm_instance, phase, cmd, cmd_type, gcode, tags, *args, **kwargs):
         if not self._printer.is_printing():

--- a/octoprint_powerfailure/__init__.py
+++ b/octoprint_powerfailure/__init__.py
@@ -120,7 +120,7 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
         ]
 
     def backupState(self):
-        currentData = self._printer. get_current_data()
+        currentData = self._printer.get_current_data()
         if currentData["job"]["file"]["origin"] != "local":
             self._logger.info(
                 "SD printing does not support power failure recovery")
@@ -155,7 +155,7 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
 
         if event.startswith("Connected"):
             self.check_recovery()
-            
+
         if event.startswith("Print"):
             if event in {"PrintStarted"}:  # empiezo a revisar
                 # empiezo a chequear
@@ -163,7 +163,7 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
                                            self], run_first=True,)
                 self.timer.start()
             # casos en que dejo de revisar y borro
-            elif event in {"PrintDone", "PrintFailed", "PrintCancelled"}:
+            elif event in {"PrintDone", "PrintCancelled"}:
                 # cancelo el chequeo
                 self.timer.cancel()
                 self.clean()

--- a/octoprint_powerfailure/__init__.py
+++ b/octoprint_powerfailure/__init__.py
@@ -143,8 +143,9 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
         self._settings.setFloat(["currentZ"], sanitize_number(currentZ))
         self._settings.setFloat(["bedT"], sanitize_number(bedT))
         self._settings.setFloat(["tool0T"], sanitize_number(tool0T))
-        self._settings.set(["extrusion"], self.extrusion)
-        self._settings.set(["last_fan"], self.last_fan)
+        if self.extrusion and self.last_fan:
+            self.settings.set(["extrusion"], self.extrusion)
+            self.settings.set(["last_fan"], self.last_fan)
         self._settings.save()
 
     def clean(self):


### PR DESCRIPTION
This PR adds python3 compatibility for current versions of OctoPrint and transitions the backup writes to a file (powerfailure_recovery.json) in the plugin data directory, instead of continually writing to settings. From my observations this significantly decreases the OctoPrint processing overhead and also enables a more broad array of potential settings to be captured and used in the regenerated gcode.