### PR TITLE
Recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OctoPrint Power Failure Recovery
 
-This plugin attempts to recover a print after a power failure or printer disconnect. Tracking printed lines during the course of a print, it can then create a recovery gcode file based on the known commands that have printed. It can be configured to start the printing automatically with the return of the power supply or a printer reconnection. Like any recovery, it is intended as a last resort and does not replace the use of proper power backup and conditioning. The results of a recovered print will vary depending on printer, material, and circumstances.  Recovered parts are certain to show small defects, but this may be acceptable in some cases.
+This plugin attempts to recover a print after a power failure or printer disconnect. Tracking printed lines during the course of a print, it can then create a recovery gcode file based on the known commands that have printed. It can be configured to start the printing automatically with the return of the power supply or a printer reconnection. Like any recovery, it is intended as a last resort and does not replace the use of proper power backup and appropriate communication setup. The results of a recovered print will vary depending on printer, material, and circumstances.  Recovered parts are certain to show small defects, but this may be acceptable in some cases.
 
 ![alt text](./extras/img/settings_screenshot.png)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # OctoPrint Power Failure Recovery
 
-Recovers a print after a power failure. This plugin generates a recovery gcode from the pre-fault offset.
-It can be configured to start the printing automatically with the return of the power supply or wait to user  or wait for user intervention.
+This plugin attempts to recover a print after a power failure or printer disconnect. Tracking printed lines during the course of a print, it can then create a recovery gcode file based on the known commands that have printed. It can be configured to start the printing automatically with the return of the power supply or a printer reconnection. Like any recovery, it is intended as a last resort and does not replace the use of proper power backup and conditioning. The results of a recovered print will vary depending on printer, material, and circumstances.  Recovered parts are certain to show small defects, but this may be acceptable in some cases.
 
 ![alt text](./extras/img/settings_screenshot.png)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ By default, when there is a power failure it generates the gcode to continue pri
 
 If you use Z_HOMING_HEIGHT in the Marlin firmware (which raises the z-axis when making a home on any axis to avoid collisions) you must set the height in the plugin configuration.
 
-For more advanced configurations, you can directly modify the injected Gcode before restarting printing in the plugin configuration.
+For slightly more advanced configurations, you can directly modify the injected Gcode before restarting printing in the plugin configuration. Defaults are based on established Marlin Gcode.
 
 ## Setup
 

--- a/octoprint_powerfailure/__init__.py
+++ b/octoprint_powerfailure/__init__.py
@@ -206,6 +206,8 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
             self.timer.cancel()
             return
         '''
+        #Can sometimes get errors if this gets called and values have not been set yet
+        #Can likely be fixed by setting timer runfirst=False
         currentTemp = self._printer.get_current_temperatures()
         bedT = currentTemp["bed"]["target"]
         tool0T = currentTemp["tool0"]["target"]

--- a/octoprint_powerfailure/__init__.py
+++ b/octoprint_powerfailure/__init__.py
@@ -80,7 +80,8 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
             gcode_prime = ("M83\n"
                     "G1 E{prime_len} F100\n"
                     "G92 E0\n"
-                    "{extrusion} ;captured from gcode, M82 or M83\n"),
+                    "{extrusion} ;captured from gcode, M82 or M83\n"
+                    ";fan state, extruder reset, feedrate and linear advance settings will be injected here\n"),
                    #goal is to restrict settings to just things that require user input, nothing below here qualifies
                    
         )

--- a/octoprint_powerfailure/__init__.py
+++ b/octoprint_powerfailure/__init__.py
@@ -112,6 +112,7 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
         self.check_recovery()
 
     def check_recovery(self):
+        self._logger.info("Checking recovery")
         self._get_recovery_settings()
         rs = self.recovery_settings
         if rs["recovery"]:
@@ -258,6 +259,7 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
             self._printer.select_file(will_print, False, printAfterSelect=True)
 
         if event.startswith("Connected"):
+            self._logger.info("Connected Event. Check Recovery")
             self.check_recovery()
 
         if event.startswith("Print"):

--- a/octoprint_powerfailure/__init__.py
+++ b/octoprint_powerfailure/__init__.py
@@ -88,8 +88,8 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
                    linear_advance=None,
                    
         )
-
-    def on_startup(self, host, port):
+        
+    def initialize(self):
         self.datafolder = self.get_plugin_data_folder()
         self.recovery_path = os.path.join(self.datafolder, self.datafile)
 

--- a/octoprint_powerfailure/templates/powerfailure_settings.jinja2
+++ b/octoprint_powerfailure/templates/powerfailure_settings.jinja2
@@ -8,6 +8,9 @@
             <label>
                 <input type="number" class="input-mini" data-bind="value: settings.plugins.powerfailure.z_homing_height"> Z_HOMING_HEIGHT
             </label>
+            <label>
+                <input type="text" class="input-mini" data-bind="numeric, value: settings.plugins.powerfailure.save_frequency"> Save Frequency (s)
+            </label>
             <h3>{{ _('Gcode initialization before continuing a print:') }}</h3>
             <label>
                 <textarea data-bind="value: settings.plugins.powerfailure.gcode"> </textarea>

--- a/octoprint_powerfailure/templates/powerfailure_settings.jinja2
+++ b/octoprint_powerfailure/templates/powerfailure_settings.jinja2
@@ -2,19 +2,41 @@
 <div>
     <form class="form-horizontal">
         <div class="controls">
-            <label class="checkbox">
-                <input type="checkbox" data-bind="checked: settings.plugins.powerfailure.auto_continue">Continue printing automatically after a power failure.
-            </label>
-            <label>
-                <input type="number" class="input-mini" data-bind="value: settings.plugins.powerfailure.z_homing_height"> Z_HOMING_HEIGHT
-            </label>
-            <label>
-                <input type="text" class="input-mini" data-bind="numeric, value: settings.plugins.powerfailure.save_frequency"> Save Frequency (s)
-            </label>
-            <h3>{{ _('Gcode initialization before continuing a print:') }}</h3>
-            <label>
-                <textarea data-bind="value: settings.plugins.powerfailure.gcode"> </textarea>
-            </label>
+            <h3>{{ _('Global Settings') }}
+                <label class="checkbox">
+                    <input type="checkbox" data-bind="checked: settings.plugins.powerfailure.auto_continue">Automatic Restart
+                    <i class="icon icon-info-sign" title="Print job will be automatically recovered once server restarts and/or the printer re-connects." data-toggle="tooltip"></i>
+                </label>
+                <label>
+                    <input type="text" class="input-mini" data-bind="numeric, value: settings.plugins.powerfailure.save_frequency"> Save Frequency (s)
+                    <i class="icon icon-info-sign" title="How often position is saved in seconds. Smaller values are more accurate at the expense of disk writes." data-toggle="tooltip"></i>
+                </label>
+            <h3>{{ _('Gcode Recovery Settings') }}
+                <i class="icon icon-info-sign" title="These Gcode sections will be concatenated with your settings to create the initial lines of recovery gcode.
+                They can be tailored to fit your specific printer. Some possible suggestions are commented out. Remove the first semi-colon to use those." data-toggle="tooltip"></i>
+            </h3>
+            <h4>{{ _('Heating:') }}</h4>
+                <label>
+                    <textarea rows="10" cols="120" data-bind="value: settings.plugins.powerfailure.gcode_temp"> </textarea>
+                </label>
+            <h4>{{ _('XY Homing:') }}</h4>
+                <label>
+                    <textarea rows="10" cols="120" data-bind="value: settings.plugins.powerfailure.gcode_xy"> </textarea>
+                </label>
+            <h4>{{ _('Z Homing:') }}</h4>
+                <h5>{{ _('Settings:') }}</h5>
+                <label>
+                    <input type="number" class="input-mini" data-bind="value: settings.plugins.powerfailure.z_homing_height"> Z_HOMING_HEIGHT
+                    <i class="icon icon-info-sign" title="If your printer raises Z before homing X and Y, put that value here. Otherwise, leave as 0." data-toggle="tooltip"></i>
+                </label>
+                <h5>{{ _('Gcode:') }}</h5>
+                <label>
+                    <textarea rows="10" cols="120" data-bind="value: settings.plugins.powerfailure.gcode_z"> </textarea>
+                </label>
+            <h4>{{ _('Extrusion/Priming:') }}</h4>
+                <label>
+                    <textarea rows="10" cols="120" data-bind="value: settings.plugins.powerfailure.gcode_prime"> </textarea>
+                </label>
         </div>
         
     </form>


### PR DESCRIPTION
This PR changes settings and how recovery is done. Information is captured from the gcode queue before being stored to disk. Recovery uses that information instead of reading back from the last known file position. This simplifies the creation of recovery gcode. Recovery gcode sections have been split into different sections to more clearly represent what they do, and to give the user the option to make changes to individual sections.