### PR TITLE
move feedrate recovery before absolute extrusion

### DIFF
--- a/octoprint_powerfailure/__init__.py
+++ b/octoprint_powerfailure/__init__.py
@@ -155,10 +155,11 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
 
         if last_fan:
             gcode_prime += last_fan + "\n"
+        #This must happen BEFORE reseting extrusion in absolute extrusion cases    
+        if feedrate:
+            gcode_prime += "G0 F" + str(feedrate) + "\n"
         if extrusion == "M82":
             gcode_prime += "G92 E" + str(extruder) + "\n"
-        if feedrate:
-            gcode_prime += "G1 F" + str(feedrate) + "\n"
         if linear_advance:
             gcode_prime += linear_advance + "\n"
 


### PR DESCRIPTION
Don't know how I missed this one before, but in cases with absolute extrusion, the feedrate must be set before the G92 that sets the extrusion. Otherwise it tries to extrude a lot of filament! (at least on my Prusa).