### PR TITLE
Rework README, version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,15 @@
 # OctoPrint Power Failure Recovery
 
-This plugin attempts to recover a print after a power failure or printer disconnect. Tracking printed lines during the course of a print, it can then create a recovery gcode file based on the known commands that have printed. Like any recovery operation, it is intended as a last resort and does not replace the use of proper power backup and appropriate communication setup. The results of a recovered print will vary depending on printer, material, and circumstances.  Recovered parts are certain to show small defects, but this may be acceptable in some cases. **To be clear: RESULTS WILL VARY**
+This plugin attempts to recover a print after a power failure or printer disconnect. Tracking printed lines during the course of a print, it can then create a recovery gcode file based on the known commands that have printed. Like any recovery operation, it is intended as a last resort and does not replace the use of proper power backup and appropriate communication setup. Because the printer buffers some commands, it is certain that some commands will be lost. The results of a recovered print will vary depending on printer, material, and in some cases, plain old luck.  Recovered parts are certain to show small defects, but this may be acceptable in some cases. **To be clear: RESULTS WILL VARY AND NO GUARANTEES ARE MADE**
 
-![alt text](./extras/img/settings_screenshot.png)
-
-## Configuration
-
-* By default, when there is a power failure the plugin generates the gcode to continue printing and only selects it, waiting for the user to continue. In the setup menu, you can select to continue printing automatically after power is restored and the connection to the printer is established.
-
-* If you use Z_HOMING_HEIGHT in the Marlin firmware (which raises the z-axis when making a home on any axis to avoid collisions) you must set the height in the plugin configuration.
-
-* For slightly more advanced configurations, you can directly modify the injected Gcode before restarting printing in the plugin configuration. Defaults are based on established Marlin Gcode.
-
-* For use with Klipper firmware, you must have the `[force_move]` with `enable_force_move=true` in your Klipper configuration and check the appropriate box in the settings. If `[safe_z_home]` is set, use the `z_hop` value as Z_HOMING_HEIGHT.
+## Settings Configuration
+* By default, when there is a power failure the plugin generates the gcode and selects the recovery file once the printer is reconnected. In the setup menu, you can select to continue printing automatically after power is restored and the connection to the printer is established. If you want the printer to recover without any intervention, you can use the Portlister plugin along with the automatic recovery feature.
+* The `Save Frequency` setting determines how often the plugin will write the current state information to disk in seconds. Lower values (0.3-0.5) provide greater accuracy at the expense of a greater number of disk writes. Larger values risk missing a greater number of commands.
+* **Critical: Determine if your printer has Z_HOMING_HEIGHT set.** This setting raises the Z-axis on any homing event to avoid collisions. You can check your printer firmware configuration or in a resting state issue the command `G28 X0 Y0` in the command terminal and observe if the Z-axis is raised, and by how much. This value is used for Z_HOMING_HEIGHT.
+* Klipper firmware. You must have the `[force_move]` section with the `enable_force_move=true` option in your Klipper configuration. Check the appropriate box in the settings. If `[safe_z_home]` is set, use the `z_hop` value as Z_HOMING_HEIGHT.
+* For slightly more advanced configurations, you can directly modify the injected Gcode before restarting printing in the plugin configuration. Defaults are based on established Marlin Gcode. All values in curly braces ({}) in the Gcode blocks are local variables that are populated by the plugin. Typically you do not want to remove these.
+* For printers that turn Z-axis motors off after some time out, it may benefit to check the `Enable Z before XY` setting. This makes a small Z movement before doing the XY homing step to prevent any movement that might result from homing.
+* Simliarly, if the Z-axis has a consistent amount of sag when the motors are disabled, this can be corrected by putting this value in for the `Sagging Z value` setting. You will have to determine this value experimentally.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This plugin attempts to recover a print after a power failure or printer disconn
 * For slightly more advanced configurations, you can directly modify the injected Gcode before restarting printing in the plugin configuration. Defaults are based on established Marlin Gcode. All values in curly braces ({}) in the Gcode blocks are local variables that are populated by the plugin. Typically you do not want to remove these.
 * For printers that turn Z-axis motors off after some time out, it may benefit to check the `Enable Z before XY` setting. This makes a small Z movement before doing the XY homing step to prevent any movement that might result from homing.
 * Simliarly, if the Z-axis has a consistent amount of sag when the motors are disabled, this can be corrected by putting this value in for the `Sagging Z value` setting. You will have to determine this value experimentally.
-
+* This plugin is in active development and feedback would be appreciated. 
 ## Setup
 
 Install via the bundled [Plugin Manager](https://github.com/foosel/OctoPrint/wiki/Plugin:-Plugin-Manager)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_powerfailure"
 plugin_name = "Power Failure Recovery"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.7"
+plugin_version = "1.1.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
I believe this plugin has now reached a state where it needs active users in order to provide feedback on its operation. This PR reworks the README to follow the current version of the settings and sets the version to 1.1.0. I recommend creating a release and submitting the plugin for inclusion in the OctoPrint plugin repository.