### PR TITLE
Move monitoring from queuing to sending; Wizard

### DIFF
--- a/octoprint_powerfailure/__init__.py
+++ b/octoprint_powerfailure/__init__.py
@@ -27,6 +27,7 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
         self.last_fan = None
         self.linear_advance = None
         self.last_tool = None
+        self.wizardVersion = 2
 
         self.recovery_settings = {
             "bedT": 0,
@@ -67,6 +68,7 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
             home_z_max=300,
             prime_len=3,
             prime_retract=0.2,
+            wizard_version = 1,
             #split gcode into X segments for more control
             #1. Start/temp
             #2. XY homing
@@ -359,6 +361,26 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
             self.recovery_settings["linear_advance"] = cmd
 
         return cmd
+        
+    def on_wizard_finish(self, handled):
+        #self._logger.debug("__init__: on_wizard_finish handled=[{}]".format(handled))
+        if handled:
+            self._settings.set(["wizard_version"], self.wizardVersion)
+            self._settings.save()
+
+    def is_wizard_required(self):
+        requiredVersion = self.wizardVersion
+        currentVersion = self._settings.get(["wizard_version"])
+        #self._logger.debug("__init__: is_wizard_required=[{}]".format(currentVersion is None or currentVersion != requiredVersion))
+        return currentVersion is None or currentVersion != requiredVersion
+
+    def get_wizard_version(self):
+        #self._logger.debug("__init__: get_wizard_version")
+        return self.wizardVersion
+
+    def get_wizard_details(self):
+        #self._logger.debug("__init__: get_wizard_details")
+        return None
 
     def get_update_information(self):
         return dict(

--- a/octoprint_powerfailure/__init__.py
+++ b/octoprint_powerfailure/__init__.py
@@ -27,6 +27,7 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
         self.last_fan = None
         self.linear_advance = None
         self.last_tool = None
+        #increment this value with each release
         self.wizardVersion = 2
 
         self.recovery_settings = {

--- a/octoprint_powerfailure/__init__.py
+++ b/octoprint_powerfailure/__init__.py
@@ -325,7 +325,7 @@ class PowerFailurePlugin(octoprint.plugin.TemplatePlugin,
             self.recovery_settings["powerloss"] = False
             self._write_recovery_settings()
 
-    def gcode_sending(self, comm_instance, phase, cmd, cmd_type, gcode, tags, *args, **kwargs):
+    def hook_gcode_sending(self, comm_instance, phase, cmd, cmd_type, gcode, tags, *args, **kwargs):
         if not self._printer.is_printing():
             return cmd
         

--- a/octoprint_powerfailure/templates/powerfailure_wizard.jinja2
+++ b/octoprint_powerfailure/templates/powerfailure_wizard.jinja2
@@ -1,0 +1,2 @@
+<div id="powerfailure_wizard">
+</div>

--- a/octoprint_powerfailure/templates/powerfailure_wizard.jinja2
+++ b/octoprint_powerfailure/templates/powerfailure_wizard.jinja2
@@ -1,2 +1,26 @@
 <div id="powerfailure_wizard">
+    <h2>Setup - Important</h2>
+        <ul>
+            <li>Determine if your printer has Z_HOMING_HEIGHT set.
+                This setting raises the Z-axis on any homing event to avoid collisions.
+                You can check your printer firmware configuration or in a resting state issue
+                the command G28 X0 Y0 in the command terminal and observe if the Z-axis is raised, and by how much.
+                This value is used for Z_HOMING_HEIGHT.</li>
+
+            <li>The Save Frequency setting determines how often the plugin will write the current state
+             information to disk in seconds. Lower values (0.3-0.5) provide greater accuracy at the expense
+             of a greater number of disk writes. Larger values risk missing a greater number of commands.</li>
+
+            <li>Klipper firmware. You must have the [force_move] section with the enable_force_move=true option
+                in your Klipper configuration. Check the appropriate box in the settings. If [safe_z_home] is set,
+                use the z_hop value as Z_HOMING_HEIGHT.</li>
+        </ul>
+    <h2>Release notes</h2>
+    Current version: 1.2.0
+    <br>
+    <ul>
+        <li>Wizard on setup</li>
+        <li>Use gcode sending instead of queuing</li>
+    </ul>
+    
 </div>

--- a/octoprint_powerfailure/templates/powerfailure_wizard.jinja2
+++ b/octoprint_powerfailure/templates/powerfailure_wizard.jinja2
@@ -4,16 +4,17 @@
             <li>Determine if your printer has Z_HOMING_HEIGHT set.
                 This setting raises the Z-axis on any homing event to avoid collisions.
                 You can check your printer firmware configuration or in a resting state issue
-                the command G28 X0 Y0 in the command terminal and observe if the Z-axis is raised, and by how much.
+                the command <i>G28 X0 Y0</i> in the command terminal and observe if the Z-axis is raised, and by how much.
                 This value is used for Z_HOMING_HEIGHT.</li>
 
             <li>The Save Frequency setting determines how often the plugin will write the current state
              information to disk in seconds. Lower values (0.3-0.5) provide greater accuracy at the expense
              of a greater number of disk writes. Larger values risk missing a greater number of commands.</li>
 
-            <li>Klipper firmware. You must have the [force_move] section with the enable_force_move=true option
-                in your Klipper configuration. Check the appropriate box in the settings. If [safe_z_home] is set,
+            <li>Klipper firmware. You must have the <i>[force_move]</i> section with the enable_force_move=true option
+                in your Klipper configuration. Check the appropriate box in the settings. If <i>[safe_z_home]</i> is set,
                 use the z_hop value as Z_HOMING_HEIGHT.</li>
+            <li>For other setting information, visit the plugin <a href="https://github.com/pablogventura/OctoPrint-PowerFailure>homepage</a>.</li>
         </ul>
     <h2>Release notes</h2>
     Current version: 1.2.0
@@ -22,5 +23,5 @@
         <li>Wizard on setup</li>
         <li>Use gcode sending instead of queuing</li>
     </ul>
-    
+
 </div>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_powerfailure"
 plugin_name = "Power Failure Recovery"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.1.1"
+plugin_version = "1.2.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
It is not likely to make a huge difference, but it makes more sense to monitor gcode from the gcode sending hook, rather than queuing, 

Also includes a Wizard so it is clear that some settings may need to be changed.